### PR TITLE
Making sure MyISAM is set

### DIFF
--- a/database/migrations/2015_07_12_114933_create_books_table.php
+++ b/database/migrations/2015_07_12_114933_create_books_table.php
@@ -13,6 +13,7 @@ class CreateBooksTable extends Migration
     public function up()
     {
         Schema::create('books', function (Blueprint $table) {
+	    $table->engine = 'MyISAM';
             $table->increments('id');
             $table->string('name');
             $table->string('slug')->indexed();

--- a/database/migrations/2015_07_12_190027_create_pages_table.php
+++ b/database/migrations/2015_07_12_190027_create_pages_table.php
@@ -13,6 +13,7 @@ class CreatePagesTable extends Migration
     public function up()
     {
         Schema::create('pages', function (Blueprint $table) {
+	    $table->engine = 'MyISAM';
             $table->increments('id');
             $table->integer('book_id');
             $table->integer('chapter_id');

--- a/database/migrations/2015_07_27_172342_create_chapters_table.php
+++ b/database/migrations/2015_07_27_172342_create_chapters_table.php
@@ -13,6 +13,7 @@ class CreateChaptersTable extends Migration
     public function up()
     {
         Schema::create('chapters', function (Blueprint $table) {
+	    $table->engine = 'MyISAM';
             $table->increments('id');
             $table->integer('book_id');
             $table->string('slug')->indexed();


### PR DESCRIPTION
This will help fix the bug where some people get the message FULLTEXT is not supported. until mysql 5.6 innodb does not support FULLTEXT by using MyISAM for the tables that require FULLTEXT this issue will be fixt. (This will only work for new installations because you can't change the type after a table is created.