### PR TITLE
Applied baseUrl to login redirect

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -40,7 +40,7 @@ class Authenticate
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);
             } else {
-                return redirect()->guest('/login');
+                return redirect()->guest(baseUrl('/login'));
             }
         }
 


### PR DESCRIPTION
If not logged in, it redirects to login form (previously without baseUrl).

As discussed on https://github.com/ssddanbrown/BookStack/issues/40#issuecomment-239105837 there may be some left over instances of this