### PR TITLE
Add Vagrant support for up and run BookStack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Homestead.yaml
 _ide_helper.php
 /storage/debugbar
 .phpstorm.meta.php
+.vagrant/
+ubuntu-xenial-16.04-cloudimg-console.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+# export http_proxy="http://proxy_host:proxy_port"
+# export https_proxy="http://proxy_host:proxy_port"
+wget https://raw.githubusercontent.com/BookStackApp/devops/master/scripts/installation-ubuntu-16.04.sh
+chmod a+x installation-ubuntu-16.04.sh
+./installation-ubuntu-16.04.sh
+echo "BookStack available by url: http://localhost:8080"
+SCRIPT
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.provider "virtualbox" do |vb|
+    vb.cpus = 1
+    vb.memory = 1024
+    vb.name = 'bookstack'
+  end
+ 
+  config.vm.define :bookstack do |config|
+    config.vm.box = "ubuntu/xenial64"
+    config.vm.boot_timeout = 1800
+    config.vm.provision "shell", inline: $script
+    config.vm.network "forwarded_port", guest: 80, host: 8080
+  end
+end


### PR DESCRIPTION
This PR add Vagrantfile for running BookStack on official Ubuntu 16.04 virtual machine, using virtualbox as provider. The BookStack is installed same as descripted in section "[Ubuntu 16.04 Installation Script](https://www.bookstackapp.com/docs/admin/installation)".
VM created with Vagrant may be using as environment for develop or testing, self hosted server and for demo purposes.

Download once, run VM and install BookStack:
`vagrant up`
After this command will done, BookStack must be available by url http://localhost:8080

SSH to VM:
`vagrant ssh`

Destroy VM
`vagrant destroy -f`

For more information about vagrant: https://www.vagrantup.com/docs/
Any feedback are welcome!